### PR TITLE
take slice of datapoint buffer when passing to metricproxy

### DIFF
--- a/poller/poller.go
+++ b/poller/poller.go
@@ -496,6 +496,13 @@ func (swc *scrapWorkCache) fillNodeDims(chosen int, dims map[string]string) {
 	}
 }
 
+func min(x, y int) int {
+	if x < y {
+		return x
+	}
+	return y
+}
+
 // Wait on channel input and forward datapoints to SignalFx.
 // This function will block.
 func (swc *scrapWorkCache) waitAndForward() {
@@ -520,7 +527,8 @@ func (swc *scrapWorkCache) waitAndForward() {
 			defer localMutex.Unlock()
 
 			if i > 0 {
-				swc.forwarder.AddDatapoints(ctx, ret)
+				min := min(i, maxDatapoints)
+				swc.forwarder.AddDatapoints(ctx, ret[:min])
 				i = 0
 			}
 		}()


### PR DESCRIPTION
Code was crashing in metricproxy due to nil pointers. I believe this was
because the buffer may have been partially full of nil pointers. This changes
it to send a slice of the datapoint buffer up to the index of the last added
datapoint.